### PR TITLE
Add TLS option for webhook

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"strconv"
+
 	"github.com/bitnami-labs/kubewatch/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,6 +44,30 @@ var webhookConfigCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		cert, err := cmd.Flags().GetString("cert")
+		if err == nil {
+			if len(cert) > 0 {
+				conf.Handler.Webhook.Cert = cert
+			}
+		} else {
+			logrus.Fatal(err)
+		}
+
+		tlsSkip, err := cmd.Flags().GetString("tlsskip")
+		if err == nil {
+			if len(tlsSkip) > 0 {
+				skip, err := strconv.ParseBool(tlsSkip)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+				conf.Handler.Webhook.TlsSkip = skip
+			} else {
+				conf.Handler.Webhook.TlsSkip = false
+			}
+		} else {
+			logrus.Fatal(err)
+		}
+
 		if err = conf.Write(); err != nil {
 			logrus.Fatal(err)
 		}
@@ -50,4 +76,6 @@ var webhookConfigCmd = &cobra.Command{
 
 func init() {
 	webhookConfigCmd.Flags().StringP("url", "u", "", "Specify Webhook url")
+	webhookConfigCmd.Flags().StringP("cert", "", "", "Specify Webhook cert path")
+	webhookConfigCmd.Flags().StringP("tlsskip", "", "", "Specify whether Webhook skips tls verify; TRUE or FALSE")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -119,7 +119,9 @@ type Flock struct {
 // Webhook contains webhook configuration
 type Webhook struct {
 	// Webhook URL.
-	Url string `json:"url"`
+	Url     string `json:"url"`
+	Cert    string `json:"cert"`
+	TlsSkip bool   `json:"tlsskip"`
 }
 
 // CloudEvent contains CloudEvent configuration

--- a/config/sample.go
+++ b/config/sample.go
@@ -26,6 +26,10 @@ handler:
   webhook:
     # Webhook URL.
     url: ""
+    # Whether skip tls or not.
+    tlsskip: ""
+    # Path of webhook cert. Default value is false.
+    cert: ""
   cloudevent:
     # CloudEvent webhook URL.
     url: ""

--- a/examples/conf/kubewatch.conf.webhook.yaml
+++ b/examples/conf/kubewatch.conf.webhook.yaml
@@ -13,7 +13,9 @@ handler:
   flock:
     url: ""
   webhook:
-    url: "http://localhost:8080"
+    url: "https://localhost:443"
+    tlsskip: false
+    cert: "/root/tls/ca.crt"
 resource:
   deployment: false
   replicationcontroller: false

--- a/pkg/handlers/webhook/webhook.go
+++ b/pkg/handlers/webhook/webhook.go
@@ -36,10 +36,11 @@ import (
 var webhookErrMsg = `
 %s
 
-You need to set Webhook url
-using "--url/-u" or using environment variables:
+You need to set Webhook url, and Webhook cert if you use self signed certificates,
+using "--url/-u" and "--cert", or using environment variables:
 
 export KW_WEBHOOK_URL=webhook_url
+export KW_WEBHOOK_CERT=/path/of/cert
 
 Command line flags will override environment variables
 


### PR DESCRIPTION
Current code cannot handle https case for webhook, so I implemented tls option.

I added two configuration for webhook; tlsskip and cert.

- tlsskip specifies whether skip tls or not. (default is false)
- cert specifies path where the cert is located.

I also updated config/sample.go and examples/kubewatch.conf.webhook.yaml for usage example.

I tried to keep code convention but I cannot sure, so any comment for my code is welcome.

Also I have a question, does this project provides any official image for kubewatch?
Because bitnami/kubewatch does not updated for last 4 months.

Thanks.
