### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ RUN install_packages ca-certificates
 
 COPY --from=builder /kubewatch /bin/kubewatch
 
+ENV KW_CONFIG=/opt/bitnami/kubewatch
+
 ENTRYPOINT ["/bin/kubewatch"]


### PR DESCRIPTION
link with https://github.com/robusta-dev/kubewatch/blob/master/config/config.go#L315 , without this add startup does not find the kubewatch.yaml in the right directory ( looking into root folder instead of /opt/bitnami/kubewatch)