### PR TITLE
need clear namespace attribute

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -526,6 +526,7 @@ func newResourceController(client kubernetes.Interface, eventHandler handlers.Ha
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			var ok bool
+			newEvent.namespace = ""
 			newEvent.key, err = cache.MetaNamespaceKeyFunc(obj)
 			newEvent.eventType = "create"
 			newEvent.resourceType = resourceType
@@ -541,6 +542,7 @@ func newResourceController(client kubernetes.Interface, eventHandler handlers.Ha
 		},
 		UpdateFunc: func(old, new interface{}) {
 			var ok bool
+			newEvent.namespace = ""
 			newEvent.key, err = cache.MetaNamespaceKeyFunc(old)
 			newEvent.eventType = "update"
 			newEvent.resourceType = resourceType


### PR DESCRIPTION
I don't know if this a clean way, but it works. Attribute 'namespace' need to be clean before Handler process a next event, otherwise you get the namespace value of previous item ( for same pair eventType / api object )