### PR TITLE
enable slackwebhook for env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -288,6 +288,9 @@ func (c *Config) CheckMissingResourceEnvvars() {
 	if (c.Handler.Slack.Token == "") && (os.Getenv("SLACK_TOKEN") != "") {
 		c.Handler.Slack.Token = os.Getenv("SLACK_TOKEN")
 	}
+	if (c.Handler.SlackWebhook.Slackwebhookurl == "") && (os.Getenv("KW_SLACK_WEBHOOK_URL") != "") {
+		c.Handler.SlackWebhook.Slackwebhookurl = os.Getenv("KW_SLACK_WEBHOOK_URL")
+	}
 }
 
 func (c *Config) Write() error {

--- a/pkg/handlers/slackwebhook/slackwebhook.go
+++ b/pkg/handlers/slackwebhook/slackwebhook.go
@@ -124,12 +124,6 @@ func (m *SlackWebhook) Handle(e event.Event) {
 }
 
 func checkMissingWebhookVars(s *SlackWebhook) error {
-	if s.Channel == "" {
-		return fmt.Errorf(webhookErrMsg, "Missing Slack Webhook Channel")
-	}
-	if s.Username == "" {
-		return fmt.Errorf(webhookErrMsg, "Missing Slack Webhook Username")
-	}
 	if s.Slackwebhookurl == "" {
 		return fmt.Errorf(webhookErrMsg, "Missing Slack Webhook url")
 	}


### PR DESCRIPTION
as mentioned in https://github.com/robusta-dev/kubewatch/edit/master/README.md L.296 KW_SLACK_WEBHOOK_URL var envs can be set in order to activate slack with webhook mode, but no place in code take care of. By the way slack webhook doesn't need anymore channel & user inputs.