### PR TITLE
Support lark webhook event notification

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -122,5 +122,6 @@ func init() {
 		cloudEventConfigCmd,
 		msteamsConfigCmd,
 		smtpConfigCmd,
+		larkConfigCmd,
 	)
 }

--- a/cmd/lark.go
+++ b/cmd/lark.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// larkConfigCmd represents the lark subcommand
+var larkConfigCmd = &cobra.Command{
+	Use:   "lark",
+	Short: "specific lark configuration",
+	Long:  `specific lark configuration`,
+	Run: func(cmd *cobra.Command, args []string) {
+		conf, err := config.New()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		url, err := cmd.Flags().GetString("webhookurl")
+		if err == nil {
+			if len(url) > 0 {
+				conf.Handler.Lark.WebhookURL = url
+			}
+		} else {
+			logrus.Fatal(err)
+		}
+
+		if err = conf.Write(); err != nil {
+			logrus.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	larkConfigCmd.Flags().StringP("webhookurl", "u", "", "Specify lark webhook url")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ supported webhooks:
  - mattermost
  - flock
  - webhook
+ - lark
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Handler struct {
 	CloudEvent   CloudEvent   `json:"cloudevent"`
 	MSTeams      MSTeams      `json:"msteams"`
 	SMTP         SMTP         `json:"smtp"`
+	Lark         Lark         `json:"lark"`
 }
 
 // Resource contains resource configuration
@@ -137,6 +138,12 @@ type Webhook struct {
 	Url     string `json:"url"`
 	Cert    string `json:"cert"`
 	TlsSkip bool   `json:"tlsskip"`
+}
+
+// Lark contains lark configuration
+type Lark struct {
+	// Webhook URL.
+	WebhookURL string `json:"webhookurl"`
 }
 
 // CloudEvent contains CloudEvent configuration

--- a/docs/design.md
+++ b/docs/design.md
@@ -28,7 +28,7 @@ necessary filtering.
 
 Handler manages how `kubewatch` handles events.
 
-With each event get from k8s and matched filtering from configuration, it is passed to handler. Currently, `kubewatch` has 7 handlers:
+With each event get from k8s and matched filtering from configuration, it is passed to handler. Currently, `kubewatch` has 8 handlers:
 
  - `Default`: which just print the event in JSON format
  - `Flock`: which send notification to Flock channel based on information from config
@@ -37,6 +37,7 @@ With each event get from k8s and matched filtering from configuration, it is pas
  - `MS Teams`: which send notification to MS Team incoming webhook based on information from config
  - `Slack`: which send notification to Slack channel based on information from config
  - `Smtp`: which sends notifications to email recipients using a SMTP server obtained from config
+ - `Lark`: which sends notifications to Lark incoming webhook based on information from config
 
 More handlers will be added in future.
 

--- a/examples/conf/kubewatch.conf.lark.yaml
+++ b/examples/conf/kubewatch.conf.lark.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubewatch
+data:
+  .kubewatch.yaml: |
+    namespace:
+    handler:
+      lark:
+        webhookurl: https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxxxxxxxxxxxxx
+    resource:
+      namespace: false
+      deployment: false
+      replicationcontroller: false
+      replicaset: false
+      daemonset: false
+      services: false
+      pod: true
+      secret: false
+      configmap: false

--- a/helm/kubewatch/templates/configmap.yaml
+++ b/helm/kubewatch/templates/configmap.yaml
@@ -40,5 +40,8 @@ data:
       {{- with .Values.extraHandlers }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{- if .Values.lark.enabled }}
+      lark: {{- toYaml .Values.lark | nindent 8 }}
+      {{- end }}
     resource: {{- toYaml .Values.resourcesToWatch | nindent 6 }}
     namespace: {{ .Values.namespaceToWatch | quote }}

--- a/helm/kubewatch/values.yaml
+++ b/helm/kubewatch/values.yaml
@@ -140,6 +140,15 @@ msteams:
 webhook:
   enabled: false
   url: ""
+
+## @param lark.enabled Enable Lark notifications
+## @param lark.url lark webhook URL
+## See: https://open.feishu.cn/document/ukTMukTMukTM/ucTM5YjL3ETO24yNxkjN
+##
+lark:
+  enabled: false
+  webhookurl: ""
+
 smtp:
   ## @param smtp.enabled Enable SMTP (email) notifications
   ##

--- a/pkg/client/run.go
+++ b/pkg/client/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/cloudevent"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/lark"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/msteam"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/slack"
@@ -62,6 +63,8 @@ func ParseEventHandler(conf *config.Config) handlers.Handler {
 		eventHandler = new(msteam.MSTeams)
 	case len(conf.Handler.SMTP.Smarthost) > 0 || len(conf.Handler.SMTP.To) > 0:
 		eventHandler = new(smtp.SMTP)
+	case len(conf.Handler.Lark.WebhookURL) > 0:
+		eventHandler = new(lark.Webhook)
 	default:
 		eventHandler = new(handlers.Default)
 	}

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bitnami-labs/kubewatch/pkg/event"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/flock"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/hipchat"
+	"github.com/bitnami-labs/kubewatch/pkg/handlers/lark"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/mattermost"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/msteam"
 	"github.com/bitnami-labs/kubewatch/pkg/handlers/slack"
@@ -47,6 +48,7 @@ var Map = map[string]interface{}{
 	"webhook":      &webhook.Webhook{},
 	"ms-teams":     &msteam.MSTeams{},
 	"smtp":         &smtp.SMTP{},
+	"lark":         &lark.Webhook{},
 }
 
 // Default handler implements Handler interface,

--- a/pkg/handlers/lark/webhook.go
+++ b/pkg/handlers/lark/webhook.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lark
+
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"os"
+
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/bitnami-labs/kubewatch/config"
+	"github.com/bitnami-labs/kubewatch/pkg/event"
+)
+
+var webhookErrMsg = `
+%s
+
+You need to set Lark Webhook url
+using "--url/-u", or using environment variables:
+
+export KW_LARK_WEBHOOK_URL=webhook_url
+
+Command line flags will override environment variables
+
+`
+
+// Webhook handler implements handler.Handler interface,
+// Notify event to Webhook channel
+type Webhook struct {
+	Url string
+}
+
+// TextMessage for messages
+type TextMessage struct {
+	MsgType string       `json:"msg_type"`
+	Content *TextContent `json:"content"`
+}
+
+type TextContent struct {
+	Text string `json:"text"`
+}
+
+// Init prepares Webhook configuration
+func (m *Webhook) Init(c *config.Config) error {
+	url := c.Handler.Lark.WebhookURL
+	if url == "" {
+		url = os.Getenv("KW_LARK_WEBHOOK_URL")
+	}
+	m.Url = url
+	return checkMissingWebhookVars(m)
+}
+
+// Handle handles an event.
+func (m *Webhook) Handle(e event.Event) {
+	webhookMessage := prepareWebhookMessage(e, m)
+
+	err := postMessage(m.Url, webhookMessage)
+	if err != nil {
+		logrus.Printf("%s\n", err)
+		return
+	}
+	logrus.Printf("Message successfully sent to lark webhook: %s at %s ", m.Url, time.Now())
+}
+
+func checkMissingWebhookVars(s *Webhook) error {
+	if s.Url == "" {
+		return fmt.Errorf(webhookErrMsg, "Missing Webhook url")
+	}
+	return nil
+}
+
+func prepareWebhookMessage(e event.Event, m *Webhook) *TextMessage {
+	return &TextMessage{
+		MsgType: "text",
+		Content: &TextContent{Text: e.Message()},
+	}
+}
+
+func postMessage(url string, textMessage *TextMessage) error {
+	message, err := json.Marshal(textMessage)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(message))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/handlers/lark/webhook_test.go
+++ b/pkg/handlers/lark/webhook_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lark
+
+import (
+	"fmt"
+	"github.com/bitnami-labs/kubewatch/config"
+	"reflect"
+	"testing"
+)
+
+func TestWebhookInit(t *testing.T) {
+	s := &Webhook{}
+	expectedError := fmt.Errorf(webhookErrMsg, "Missing Webhook url")
+
+	var Tests = []struct {
+		lark config.Lark
+		err  error
+	}{
+		{config.Lark{WebhookURL: "foo"}, nil},
+		{config.Lark{}, expectedError},
+	}
+	for _, tt := range Tests {
+		c := &config.Config{}
+		c.Handler.Lark = tt.lark
+		if err := s.Init(c); !reflect.DeepEqual(err, tt.err) {
+			t.Fatalf("Init(): %v", err)
+		}
+	}
+}


### PR DESCRIPTION
[larksuite](https://www.larksuite.com/) is an enterprise collaboration platform, which is used by many companies. It's better to support sending event notifications from k8s cluster to lark app through lark webhook(https://open.feishu.cn/document/ukTMukTMukTM/ucTM5YjL3ETO24yNxkjN?lang=en-US)