### PR TITLE
Default false for all notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ When you have helm installed in your cluster, use the following setup:
 
 ```console
 helm repo add robusta https://robusta-charts.storage.googleapis.com && helm repo update
-helm install kubewatch robusta/kubewatch --set='rbac.create=true,slack.channel=#YOUR_CHANNEL,slack.token=xoxb-YOUR_TOKEN,resourcesToWatch.pod=true,resourcesToWatch.daemonset=true'
+helm install kubewatch robusta/kubewatch --set='rbac.create=true,slack.enabled=true,slack.channel=#YOUR_CHANNEL,slack.token=xoxb-YOUR_TOKEN,resourcesToWatch.pod=true,resourcesToWatch.daemonset=true'
 ```
 
 You may also provide a values file instead:

--- a/helm/kubewatch/README.md
+++ b/helm/kubewatch/README.md
@@ -77,7 +77,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`                       | Kubewatch image pull policy                                                      | `IfNotPresent`         |
 | `image.pullSecrets`                      | Specify docker-registry secret names as an array                                 | `[]`                   |
 | `hostAliases`                            | Add deployment host aliases                                                      | `[]`                   |
-| `slack.enabled`                          | Enable Slack notifications                                                       | `true`                 |
+| `slack.enabled`                          | Enable Slack notifications                                                       | `false`                 |
 | `slack.channel`                          | Slack channel to notify                                                          | `XXXX`                 |
 | `slack.token`                            | Slack API token                                                                  | `XXXX`                 |
 | `hipchat.enabled`                        | Enable HipChat notifications                                                     | `false`                |
@@ -190,7 +190,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install my-release bitnami/kubewatch \
-  --set=slack.channel="#bots",slack.token="XXXX-XXXX-XXXX"
+  --set=slack.enabled="true",slack.channel="#bots",slack.token="XXXX-XXXX-XXXX"
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,

--- a/helm/kubewatch/values.yaml
+++ b/helm/kubewatch/values.yaml
@@ -85,7 +85,7 @@ hostAliases: []
 ## @param slack.token Slack API token
 ##
 slack:
-  enabled: true
+  enabled: false
   channel: "XXXX"
   ## Create using: https://my.slack.com/services/new/bot and invite the bot to your channel using: /join @botname
   ##


### PR DESCRIPTION
 Hi, i think we should set `false` for all notification channels, example when configuring with `msteam`, I am not aware `slack` default `true` so need to check logs to debug issue