### PR TITLE
Dockerfile: switch to Chainguard static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ ADD . "$GOPATH/src/github.com/bitnami-labs/kubewatch"
 RUN cd "$GOPATH/src/github.com/bitnami-labs/kubewatch" && \
     CGO_ENABLED=0 GOOS=linux GOARCH=$(dpkg --print-architecture) go build -a --installsuffix cgo --ldflags="-s" -o /kubewatch
 
-FROM bitnami/minideb:bullseye
-RUN install_packages ca-certificates
+FROM cgr.dev/chainguard/static:latest-glibc
 
 COPY --from=builder /kubewatch /bin/kubewatch
 


### PR DESCRIPTION
I switch from minideb to Chainguard's static image (this one has ca-certificates-bundle installed already, hence I remove the RUN instruction)

minideb has lots of CVE:

![image](https://user-images.githubusercontent.com/627278/230954328-5bfeefdf-9f74-4f77-8981-5b591c066d3e.png)

```
Total: 76 (UNKNOWN: 0, LOW: 58, MEDIUM: 8, HIGH: 9, CRITICAL: 1)
```

After switch to Chainguard's static, only 14 left. all are coming from kubewatch's dependencies, which I can patch in another PR.

![image](https://user-images.githubusercontent.com/627278/230954272-d5825b58-0bc0-4ce9-b73f-0aeee19ae716.png)

Also, size has reduce from 112MB down to 33MB

![image](https://user-images.githubusercontent.com/627278/230954603-d6cabdec-98e7-4509-9227-615329cc0787.png)
 