### PR TITLE
updated events object for newer k8s support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 # Latest image
 
 ```
-us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.4
+us-central1-docker.pkg.dev/genuine-flight-317411/devel/kubewatch:v2.5
 ```
 
 # Usage
@@ -92,6 +92,7 @@ resourcesToWatch:
   secret: false
   configmap: false
   ingress: false
+  coreevent: false
   event: true
 slack:
   channel: '#YOUR_CHANNEL'
@@ -148,6 +149,7 @@ resource:
   secret: false
   configmap: false
   ingress: false
+  coreevent: false
   event: true
 ```
 
@@ -344,6 +346,7 @@ data:
       serviceaccount: false
       services: true
       event: true
+      coreevent: false
     ```
 
 ### flock:
@@ -426,6 +429,7 @@ resource:
   configmap: false
   ingress: false
   event: true
+  coreevent: false
 namespace: ""
 
 ```
@@ -467,6 +471,7 @@ Flags:
       --sa                      watch for service accounts
       --secret                  watch for plain secrets
       --svc                     watch for services
+      --coreevent               watch for events from the kubernetes core api. (Old events api, replaced in kubernetes 1.19)
 
 Use "kubewatch resource [command] --help" for more information about a command.
 
@@ -501,6 +506,7 @@ Global Flags:
       --sa                      watch for service accounts
       --secret                  watch for plain secrets
       --svc                     watch for services
+      --coreevent               watch for events from the kubernetes core api. (Old events api, replaced in kubernetes 1.19)
 
 ```
 

--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -149,6 +149,10 @@ func configureResource(operation string, cmd *cobra.Command, conf *config.Config
 			"statefulset",
 			&conf.Resource.StatefulSet,
 		},
+		{
+			"coreevent",
+			&conf.Resource.CoreEvent,
+		},
 	}
 
 	for _, flag := range flags {
@@ -197,4 +201,5 @@ func init() {
 	resourceConfigCmd.PersistentFlags().Bool("clusterrole", false, "watch for cluster roles")
 	resourceConfigCmd.PersistentFlags().Bool("clusterrolebinding", false, "watch for cluster roles binding")
 	resourceConfigCmd.PersistentFlags().Bool("sa", false, "watch for service accounts")
+	resourceConfigCmd.PersistentFlags().Bool("coreevent", false, "watch for events (old events object)")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type Resource struct {
 	Ingress               bool `json:"ing"`
 	HPA                   bool `json:"hpa"`
 	Event                 bool `json:"event"`
+	CoreEvent             bool `json:"coreevent"`
 }
 
 // Config struct contains kubewatch configuration

--- a/examples/conf/kubewatch.conf.flock.yaml
+++ b/examples/conf/kubewatch.conf.flock.yaml
@@ -12,3 +12,4 @@ resource:
   persistentvolume: false
   ingress: false
   event: false
+  coreevent: false

--- a/examples/conf/kubewatch.conf.hipchat.yaml
+++ b/examples/conf/kubewatch.conf.hipchat.yaml
@@ -14,3 +14,4 @@ resource:
   persistentvolume: false
   ingress: false
   event: false
+  coreevent: false

--- a/examples/conf/kubewatch.conf.mattermost.yaml
+++ b/examples/conf/kubewatch.conf.mattermost.yaml
@@ -14,3 +14,4 @@ resource:
   persistentvolume: false
   ingress: false
   event: false
+  coreevent: false

--- a/kubewatch-configmap.yaml
+++ b/kubewatch-configmap.yaml
@@ -20,4 +20,5 @@ data:
       secret: false
       configmap: false
       hpa: false
+      coreevent: false
       event: true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -109,7 +109,7 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 					return kubeClient.CoreV1().Events(conf.Namespace).Watch(context.Background(), options)
 				},
 			},
-			&events_v1.Event{},
+			&api_v1.Event{},
 			0, //Skip resync
 			cache.Indexers{},
 		)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -36,6 +36,7 @@ import (
 	autoscaling_v1 "k8s.io/api/autoscaling/v1"
 	batch_v1 "k8s.io/api/batch/v1"
 	api_v1 "k8s.io/api/core/v1"
+	events_v1 "k8s.io/api/events/v1"
 	networking_v1 "k8s.io/api/networking/v1"
 	rbac_v1 "k8s.io/api/rbac/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,7 @@ const APPS_V1 = "apps/v1"
 const BATCH_V1 = "batch/v1"
 const RBAC_V1 = "rbac.authorization.k8s.io/v1"
 const NETWORKING_V1 = "networking.k8s.io/v1"
+const EVENTS_V1 = "events.k8s.io/v1"
 
 var serverStartTime time.Time
 
@@ -100,19 +102,19 @@ func Start(conf *config.Config, eventHandler handlers.Handler) {
 			&cache.ListWatch{
 				ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 					options.FieldSelector = ""
-					return kubeClient.CoreV1().Events(conf.Namespace).List(context.Background(), options)
+					return kubeClient.EventsV1().Events(conf.Namespace).List(context.Background(), options)
 				},
 				WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
 					options.FieldSelector = ""
-					return kubeClient.CoreV1().Events(conf.Namespace).Watch(context.Background(), options)
+					return kubeClient.EventsV1().Events(conf.Namespace).Watch(context.Background(), options)
 				},
 			},
-			&api_v1.Event{},
+			&events_v1.Event{},
 			0, //Skip resync
 			cache.Indexers{},
 		)
 
-		allEventsController := newResourceController(kubeClient, eventHandler, allEventsInformer, objName(api_v1.Event{}), V1)
+		allEventsController := newResourceController(kubeClient, eventHandler, allEventsInformer, objName(events_v1.Event{}), EVENTS_V1)
 		stopAllEventsCh := make(chan struct{})
 		defer close(stopAllEventsCh)
 

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -10,6 +10,7 @@ import (
 	ext_v1beta1 "k8s.io/api/extensions/v1beta1"
 	networking_v1 "k8s.io/api/networking/v1"
 	rbac_v1 "k8s.io/api/rbac/v1"
+	events_v1 "k8s.io/api/events/v1"
 	rbac_v1beta1 "k8s.io/api/rbac/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -97,7 +98,7 @@ func GetObjectMetaData(obj interface{}) (objectMeta meta_v1.ObjectMeta) {
 		objectMeta = object.ObjectMeta
 	case *api_v1.ConfigMap:
 		objectMeta = object.ObjectMeta
-	case *api_v1.Event:
+	case *events_v1.Event:
 		objectMeta = object.ObjectMeta
 	}
 	return objectMeta

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -98,6 +98,8 @@ func GetObjectMetaData(obj interface{}) (objectMeta meta_v1.ObjectMeta) {
 		objectMeta = object.ObjectMeta
 	case *api_v1.ConfigMap:
 		objectMeta = object.ObjectMeta
+	case *api_v1.Event:
+		objectMeta = object.ObjectMeta
 	case *events_v1.Event:
 		objectMeta = object.ObjectMeta
 	}


### PR DESCRIPTION
The events object was added since version 1.19
For kubernetes versions before 1.19 they should use kubewatch versions from v2.4 and before
