### PR TITLE
Add Cloudevent section to Helm chart ConfigMap

### DIFF
--- a/helm/kubewatch/templates/configmap.yaml
+++ b/helm/kubewatch/templates/configmap.yaml
@@ -31,6 +31,9 @@ data:
       {{- if .Values.webhook.enabled }}
       webhook: {{- toYaml .Values.webhook | nindent 8 }}
       {{- end }}
+      {{- if .Values.cloudevent.enabled }}
+      cloudevent: {{- toYaml .Values.cloudevent | nindent 8 }}
+      {{- end }}
       {{- if .Values.smtp.enabled }}
       smtp: {{- toYaml .Values.smtp | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
There was missing Cloudevent section in Helm chart ConfigMap. This section is required to configure Cloudevent webhook.