### PR TITLE
Add: argo rollouts events

### DIFF
--- a/helm/kubewatch/templates/clusterrole.yaml
+++ b/helm/kubewatch/templates/clusterrole.yaml
@@ -76,6 +76,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+      - rollouts/status
+      - experiments
+      - analysisruns
+      - analysistemplates
+      - clusteranalysistemplates
   {{- range .Values.rbac.customRoles }}
   - apiGroups: {{ toYaml .apiGroups | nindent 4 }}
     resources: {{ toYaml .resources | nindent 4 }}


### PR DESCRIPTION
- I'm Interested in this project. While testing the project, I found that the authority of Argo Rollouts, which people have been using a lot recently, was missing.